### PR TITLE
🔨 Fix: #2 optional utilities styles added

### DIFF
--- a/demo/src/pages/Utilities.tsx
+++ b/demo/src/pages/Utilities.tsx
@@ -2,6 +2,8 @@ import { Link, useParams } from 'react-router-dom';
 
 import CodeBlock from '../components/CodeBlock';
 
+import './styles-utilities.scss';
+
 const TABS = [
   { id: 'display', label: 'Display' },
   { id: 'flex', label: 'Flexbox' },

--- a/demo/src/pages/styles-utilities.scss
+++ b/demo/src/pages/styles-utilities.scss
@@ -1,0 +1,11 @@
+// Import additional Cybercore utility styles
+@use "../../../src/scss/utilities/backgrounds";
+@use "../../../src/scss/utilities/borders";
+@use "../../../src/scss/utilities/shadows";
+@use "../../../src/scss/utilities/transforms";
+@use "../../../src/scss/utilities/transitions";
+@use "../../../src/scss/utilities/position";
+@use "../../../src/scss/utilities/sizing";
+@use "../../../src/scss/utilities/layout";
+@use "../../../src/scss/utilities/interactivity";
+@use "../../../src/scss/utilities/filters";


### PR DESCRIPTION
Bug #2. Demo site didn't load all the optional stylesheets. Added a "barrel" SCSS to the missing styles.

### Before

<img src="https://private-user-images.githubusercontent.com/27637/562867960-a6c30899-49b4-4be9-8bd0-bafccefe0325.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzM0NjUzNjAsIm5iZiI6MTc3MzQ2NTA2MCwicGF0aCI6Ii8yNzYzNy81NjI4Njc5NjAtYTZjMzA4OTktNDliNC00YmU5LThiZDAtYmFmY2NlZmUwMzI1LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAzMTQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMzE0VDA1MTEwMFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTRiMjNiZTE5NjY5OGIzYjk2OTlhYTIxYjlkMzlhMzUzZGQxZjRiZTc0ZTIyNGQzYjgwMGYwMTYzYmZiNGIxNTAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.E4BLine8IrB6ZDsTrS1Y9Ty8-7ExIVauGW8sdNhcjRk" alt="before screenshot" />

### After

<img alt="After Screenshot" src="https://github.com/user-attachments/assets/c79a75d6-37ce-4d5e-9442-c182942a636d" />
