### PR TITLE
Adding .cyber-input-group and .cyber-input-group__addon to _inputs.scss

### DIFF
--- a/src/scss/components/_inputs.scss
+++ b/src/scss/components/_inputs.scss
@@ -36,6 +36,24 @@
   }
 
   // --------------------------------------------------------
+  // Input group wrapper (icon + input)
+  // --------------------------------------------------------
+
+  .cyber-input-group {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-bg-default);
+    border-radius: var(--radius-cyber);
+    padding: 0 var(--space-sm);
+
+    &__addon {
+        flex-shrink:0;
+    }
+  }
+
+  // --------------------------------------------------------
   // Field wrapper (label + input)
   // --------------------------------------------------------
 


### PR DESCRIPTION
The last example shown in demo at page [https://sebyx07.github.io/cybercore-css/#/components/inputs](https://sebyx07.github.io/cybercore-css/#/components/inputs) shows two classes:
- .cyber-input-group;
- .cyber-input-group__addon. 

Since I cannot find them in the code, I'm proposing to add them.

<img width="1475" height="654" alt="inputs" src="https://github.com/user-attachments/assets/c3e87f9e-762a-4453-a030-2e22d568ad4d" />
