### PR TITLE
Fix  .cyber-nav__link in _nav.scss

### DIFF
--- a/src/scss/components/_nav.scss
+++ b/src/scss/components/_nav.scss
@@ -44,6 +44,7 @@
   }
 
   .cyber-nav__link {
+    display: inline-block;
     position: relative;
     padding: var(--space-xs) var(--space-sm);
     overflow: hidden;


### PR DESCRIPTION
Adding display: inline-block; to fix .cyber-nav__link

Without that line of code this error shows up:
<img width="514" height="131" alt="Screenshot 2026-07-31 at 12-23-00 Home" src="https://github.com/user-attachments/assets/501b11c1-41c3-4e83-ae0a-85c1d47962fa" />
